### PR TITLE
feat(exports): add async CSV export jobs

### DIFF
--- a/src/main/java/com/lenaneshcheret/taskmanager/config/ExportProperties.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/config/ExportProperties.java
@@ -1,0 +1,15 @@
+package com.lenaneshcheret.taskmanager.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "app.exports")
+@Getter
+@Setter
+public class ExportProperties {
+
+  private String storageDir = "target/exports";
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/controller/ExportController.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/controller/ExportController.java
@@ -1,0 +1,58 @@
+package com.lenaneshcheret.taskmanager.controller;
+
+import com.lenaneshcheret.taskmanager.controller.dto.ExportJobResponse;
+import com.lenaneshcheret.taskmanager.controller.dto.ExportRequest;
+import com.lenaneshcheret.taskmanager.service.ExportService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/exports")
+@RequiredArgsConstructor
+public class ExportController {
+
+  private static final MediaType CSV_MEDIA_TYPE = MediaType.parseMediaType("text/csv");
+
+  private final ExportService exportService;
+
+  @PostMapping
+  public ResponseEntity<ExportJobResponse> create(
+      @Valid @RequestBody ExportRequest request,
+      JwtAuthenticationToken authentication
+  ) {
+    ExportJobResponse response = ExportJobResponse.from(
+        exportService.requestExport(request.projectId(), request.type(), authentication)
+    );
+    return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+  }
+
+  @GetMapping("/{jobId}")
+  public ExportJobResponse getStatus(@PathVariable Long jobId, JwtAuthenticationToken authentication) {
+    return ExportJobResponse.from(exportService.getStatus(jobId, authentication));
+  }
+
+  @GetMapping("/{jobId}/download")
+  public ResponseEntity<byte[]> download(@PathVariable Long jobId, JwtAuthenticationToken authentication) {
+    ExportService.ExportDownload exportDownload = exportService.download(jobId, authentication);
+
+    return ResponseEntity.ok()
+        .contentType(CSV_MEDIA_TYPE)
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            ContentDisposition.attachment().filename(exportDownload.fileName()).build().toString()
+        )
+        .body(exportDownload.content());
+  }
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/controller/dto/ExportJobResponse.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/controller/dto/ExportJobResponse.java
@@ -1,0 +1,29 @@
+package com.lenaneshcheret.taskmanager.controller.dto;
+
+import com.lenaneshcheret.taskmanager.domain.ExportJob;
+import com.lenaneshcheret.taskmanager.domain.ExportJobStatus;
+import com.lenaneshcheret.taskmanager.domain.ExportJobType;
+import java.time.Instant;
+
+public record ExportJobResponse(
+    Long jobId,
+    Long projectId,
+    ExportJobType type,
+    ExportJobStatus status,
+    Instant createdAt,
+    Instant finishedAt,
+    String errorMessage
+) {
+
+  public static ExportJobResponse from(ExportJob exportJob) {
+    return new ExportJobResponse(
+        exportJob.getId(),
+        exportJob.getProjectId(),
+        exportJob.getType(),
+        exportJob.getStatus(),
+        exportJob.getCreatedAt(),
+        exportJob.getFinishedAt(),
+        exportJob.getErrorMessage()
+    );
+  }
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/controller/dto/ExportRequest.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/controller/dto/ExportRequest.java
@@ -1,0 +1,12 @@
+package com.lenaneshcheret.taskmanager.controller.dto;
+
+import com.lenaneshcheret.taskmanager.domain.ExportJobType;
+import jakarta.validation.constraints.NotNull;
+
+public record ExportRequest(
+    @NotNull(message = "projectId is required")
+    Long projectId,
+    @NotNull(message = "type is required")
+    ExportJobType type
+) {
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/domain/ExportJob.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/domain/ExportJob.java
@@ -30,6 +30,10 @@ public class ExportJob {
   @Setter
   private Long userId;
 
+  @Column(name = "project_id")
+  @Setter
+  private Long projectId;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 50)
   @Setter
@@ -51,6 +55,10 @@ public class ExportJob {
   @Setter
   private String filePath;
 
+  @Column(name = "error_message", columnDefinition = "TEXT")
+  @Setter
+  private String errorMessage;
+
   @Version
   @Column(nullable = false)
   private Long version;
@@ -60,5 +68,38 @@ public class ExportJob {
     if (createdAt == null) {
       createdAt = Instant.now();
     }
+  }
+
+  public static ExportJob pending(Long userId, Long projectId, ExportJobType type) {
+    ExportJob exportJob = new ExportJob();
+    exportJob.userId = userId;
+    exportJob.projectId = projectId;
+    exportJob.type = type;
+    exportJob.status = ExportJobStatus.PENDING;
+    exportJob.finishedAt = null;
+    exportJob.filePath = null;
+    exportJob.errorMessage = null;
+    return exportJob;
+  }
+
+  public void markRunning() {
+    status = ExportJobStatus.RUNNING;
+    filePath = null;
+    finishedAt = null;
+    errorMessage = null;
+  }
+
+  public void markDone(String filePath, Instant finishedAt) {
+    status = ExportJobStatus.DONE;
+    this.filePath = filePath;
+    this.finishedAt = finishedAt;
+    errorMessage = null;
+  }
+
+  public void markFailed(String errorMessage, Instant finishedAt) {
+    status = ExportJobStatus.FAILED;
+    filePath = null;
+    this.errorMessage = errorMessage;
+    this.finishedAt = finishedAt;
   }
 }

--- a/src/main/java/com/lenaneshcheret/taskmanager/domain/ExportJobStatus.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/domain/ExportJobStatus.java
@@ -3,6 +3,6 @@ package com.lenaneshcheret.taskmanager.domain;
 public enum ExportJobStatus {
   PENDING,
   RUNNING,
-  COMPLETED,
+  DONE,
   FAILED
 }

--- a/src/main/java/com/lenaneshcheret/taskmanager/repository/ExportJobRepository.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/repository/ExportJobRepository.java
@@ -1,7 +1,18 @@
 package com.lenaneshcheret.taskmanager.repository;
 
 import com.lenaneshcheret.taskmanager.domain.ExportJob;
+import java.util.Optional;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ExportJobRepository extends JpaRepository<ExportJob, Long> {
+
+  Optional<ExportJob> findByIdAndUserId(Long id, Long userId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select e from ExportJob e where e.id = :jobId")
+  Optional<ExportJob> findByIdForUpdate(@Param("jobId") Long jobId);
 }

--- a/src/main/java/com/lenaneshcheret/taskmanager/repository/TaskRepository.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/repository/TaskRepository.java
@@ -35,4 +35,6 @@ public interface TaskRepository extends JpaRepository<Task, Long>, JpaSpecificat
       @Param("windowEnd") Instant windowEnd,
       @Param("completedStatus") TaskStatus completedStatus
   );
+
+  List<Task> findAllByProjectIdOrderByIdAsc(Long projectId);
 }

--- a/src/main/java/com/lenaneshcheret/taskmanager/service/CsvExportWriter.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/service/CsvExportWriter.java
@@ -1,0 +1,67 @@
+package com.lenaneshcheret.taskmanager.service;
+
+import com.lenaneshcheret.taskmanager.config.ExportProperties;
+import com.lenaneshcheret.taskmanager.domain.Task;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CsvExportWriter {
+
+  private final ExportProperties exportProperties;
+
+  public Path write(Long jobId, Long projectId, List<Task> tasks) throws IOException {
+    Path storageDir = Path.of(exportProperties.getStorageDir());
+    Files.createDirectories(storageDir);
+
+    Path csvPath = storageDir.resolve("project-" + projectId + "-export-" + jobId + ".csv");
+    Files.writeString(
+        csvPath,
+        render(tasks),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE
+    );
+    return csvPath;
+  }
+
+  private String render(List<Task> tasks) {
+    StringBuilder csv = new StringBuilder();
+    csv.append("id,title,description,status,dueAt,completedAt,priority").append('\n');
+
+    for (Task task : tasks) {
+      csv.append(task.getId()).append(',')
+          .append(escape(task.getTitle())).append(',')
+          .append(escape(task.getDescription())).append(',')
+          .append(task.getStatus()).append(',')
+          .append(value(task.getDueAt())).append(',')
+          .append(value(task.getCompletedAt())).append(',')
+          .append(task.getPriority())
+          .append('\n');
+    }
+
+    return csv.toString();
+  }
+
+  private String value(Object value) {
+    return value == null ? "" : escape(value.toString());
+  }
+
+  private String escape(String value) {
+    if (value == null) {
+      return "";
+    }
+    if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/service/ExportAsyncWorker.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/service/ExportAsyncWorker.java
@@ -1,0 +1,44 @@
+package com.lenaneshcheret.taskmanager.service;
+
+import com.lenaneshcheret.taskmanager.domain.ExportJobType;
+import com.lenaneshcheret.taskmanager.domain.Task;
+import com.lenaneshcheret.taskmanager.repository.TaskRepository;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExportAsyncWorker {
+
+  private final ExportJobLifecycleService exportJobLifecycleService;
+  private final TaskRepository taskRepository;
+  private final CsvExportWriter csvExportWriter;
+
+  @Async
+  public void process(Long jobId) {
+    exportJobLifecycleService.start(jobId)
+        .ifPresent(this::runExport);
+  }
+
+  private void runExport(ExportJobLifecycleService.ExportJobExecution execution) {
+    try {
+      Path filePath = generateFile(execution);
+      exportJobLifecycleService.complete(execution.jobId(), filePath.toString());
+    } catch (RuntimeException | IOException exception) {
+      exportJobLifecycleService.fail(execution.jobId(), exception.getMessage());
+    }
+  }
+
+  private Path generateFile(ExportJobLifecycleService.ExportJobExecution execution) throws IOException {
+    if (execution.type() != ExportJobType.CSV) {
+      throw new IllegalArgumentException("Unsupported export type: " + execution.type());
+    }
+
+    List<Task> tasks = taskRepository.findAllByProjectIdOrderByIdAsc(execution.projectId());
+    return csvExportWriter.write(execution.jobId(), execution.projectId(), tasks);
+  }
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/service/ExportJobLifecycleService.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/service/ExportJobLifecycleService.java
@@ -1,0 +1,55 @@
+package com.lenaneshcheret.taskmanager.service;
+
+import com.lenaneshcheret.taskmanager.domain.ExportJobStatus;
+import com.lenaneshcheret.taskmanager.domain.ExportJobType;
+import com.lenaneshcheret.taskmanager.repository.ExportJobRepository;
+import java.time.Clock;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExportJobLifecycleService {
+
+  private static final int MAX_ERROR_LENGTH = 1_000;
+
+  private final ExportJobRepository exportJobRepository;
+  private final Clock clock;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public Optional<ExportJobExecution> start(Long jobId) {
+    return exportJobRepository.findByIdForUpdate(jobId)
+        .filter(job -> job.getStatus() == ExportJobStatus.PENDING)
+        .map(job -> {
+          job.markRunning();
+          return new ExportJobExecution(job.getId(), job.getProjectId(), job.getType());
+        });
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void complete(Long jobId, String filePath) {
+    exportJobRepository.findByIdForUpdate(jobId)
+        .ifPresent(job -> job.markDone(filePath, clock.instant()));
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void fail(Long jobId, String errorMessage) {
+    exportJobRepository.findByIdForUpdate(jobId)
+        .ifPresent(job -> job.markFailed(truncate(errorMessage), clock.instant()));
+  }
+
+  public record ExportJobExecution(Long jobId, Long projectId, ExportJobType type) {
+  }
+
+  private String truncate(String errorMessage) {
+    if (errorMessage == null || errorMessage.isBlank()) {
+      return "Export generation failed";
+    }
+    return errorMessage.length() <= MAX_ERROR_LENGTH
+        ? errorMessage
+        : errorMessage.substring(0, MAX_ERROR_LENGTH);
+  }
+}

--- a/src/main/java/com/lenaneshcheret/taskmanager/service/ExportService.java
+++ b/src/main/java/com/lenaneshcheret/taskmanager/service/ExportService.java
@@ -1,0 +1,82 @@
+package com.lenaneshcheret.taskmanager.service;
+
+import com.lenaneshcheret.taskmanager.domain.ExportJob;
+import com.lenaneshcheret.taskmanager.domain.ExportJobStatus;
+import com.lenaneshcheret.taskmanager.domain.ExportJobType;
+import com.lenaneshcheret.taskmanager.repository.ExportJobRepository;
+import com.lenaneshcheret.taskmanager.repository.ProjectRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class ExportService {
+
+  private final ExportJobRepository exportJobRepository;
+  private final ProjectRepository projectRepository;
+  private final CurrentUserService currentUserService;
+  private final ExportAsyncWorker exportAsyncWorker;
+
+  public ExportJob requestExport(Long projectId, ExportJobType type, JwtAuthenticationToken authentication) {
+    Long ownerId = currentUserService.getOrCreateCurrentUser(authentication).getId();
+    ensureOwnedProject(projectId, ownerId);
+    ensureSupportedType(type);
+
+    ExportJob exportJob = exportJobRepository.save(ExportJob.pending(ownerId, projectId, type));
+    exportAsyncWorker.process(exportJob.getId());
+    return exportJob;
+  }
+
+  public ExportJob getStatus(Long jobId, JwtAuthenticationToken authentication) {
+    return findOwnedJob(jobId, authentication);
+  }
+
+  public ExportDownload download(Long jobId, JwtAuthenticationToken authentication) {
+    ExportJob exportJob = findOwnedJob(jobId, authentication);
+    if (exportJob.getStatus() != ExportJobStatus.DONE) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Export is not ready for download");
+    }
+    if (exportJob.getFilePath() == null || exportJob.getFilePath().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Export is not ready for download");
+    }
+
+    Path filePath = Path.of(exportJob.getFilePath());
+    try {
+      return new ExportDownload(
+          "project-" + exportJob.getProjectId() + "-export-" + exportJob.getId() + ".csv",
+          Files.readAllBytes(filePath)
+      );
+    } catch (IOException exception) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Export file is unavailable");
+    }
+  }
+
+  private ExportJob findOwnedJob(Long jobId, JwtAuthenticationToken authentication) {
+    Long ownerId = currentUserService.getOrCreateCurrentUser(authentication).getId();
+    return exportJobRepository.findByIdAndUserId(jobId, ownerId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Export job not found"));
+  }
+
+  private void ensureOwnedProject(Long projectId, Long ownerId) {
+    projectRepository.findByIdAndOwnerId(projectId, ownerId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found"));
+  }
+
+  private void ensureSupportedType(ExportJobType type) {
+    if (type == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "type is required");
+    }
+    if (type != ExportJobType.CSV) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only CSV exports are supported");
+    }
+  }
+
+  public record ExportDownload(String fileName, byte[] content) {
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,8 @@ app:
   security:
     oauth2:
       client-id: ${APP_SECURITY_OAUTH2_CLIENT_ID:task-manager-api}
+  exports:
+    storage-dir: ${APP_EXPORTS_STORAGE_DIR:target/exports}
   reminders:
     due-window: ${APP_REMINDERS_DUE_WINDOW:PT15M}
     enqueue-fixed-delay-ms: ${APP_REMINDERS_ENQUEUE_FIXED_DELAY_MS:60000}

--- a/src/main/resources/db/migration/V5__extend_export_jobs_for_async_csv.sql
+++ b/src/main/resources/db/migration/V5__extend_export_jobs_for_async_csv.sql
@@ -1,0 +1,17 @@
+ALTER TABLE export_jobs
+    ADD COLUMN project_id BIGINT,
+    ADD COLUMN error_message TEXT;
+
+ALTER TABLE export_jobs
+    ADD CONSTRAINT fk_export_jobs_project_id
+        FOREIGN KEY (project_id)
+        REFERENCES projects (id)
+        ON DELETE CASCADE;
+
+UPDATE export_jobs
+SET status = 'DONE'
+WHERE status = 'COMPLETED';
+
+CREATE INDEX IF NOT EXISTS idx_export_jobs_user_id_status ON export_jobs (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_export_jobs_project_id_created_at ON export_jobs (project_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_export_jobs_type_status ON export_jobs (type, status);

--- a/src/test/java/com/lenaneshcheret/taskmanager/export/ExportEndpointIntegrationTest.java
+++ b/src/test/java/com/lenaneshcheret/taskmanager/export/ExportEndpointIntegrationTest.java
@@ -1,0 +1,254 @@
+package com.lenaneshcheret.taskmanager.export;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.Matchers.containsString;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ExportEndpointIntegrationTest {
+
+  private static final Path REALM_IMPORT_FILE = Path.of("infra", "keycloak", "realm-export.json")
+      .toAbsolutePath();
+
+  private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+      DockerImageName.parse("postgres:16-alpine")
+  );
+
+  private static final GenericContainer<?> KEYCLOAK = new GenericContainer<>(
+      DockerImageName.parse("quay.io/keycloak/keycloak:24.0")
+  )
+      .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
+      .withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
+      .withCommand("start-dev", "--import-realm")
+      .withCopyFileToContainer(
+          MountableFile.forHostPath(REALM_IMPORT_FILE.toString()),
+          "/opt/keycloak/data/import/realm-export.json"
+      )
+      .withExposedPorts(8080)
+      .waitingFor(Wait.forHttp("/realms/task-manager/.well-known/openid-configuration").forStatusCode(200))
+      .withStartupTimeout(Duration.ofMinutes(3));
+
+  static {
+    Startables.deepStart(Stream.of(POSTGRES, KEYCLOAK)).join();
+  }
+
+  @LocalServerPort
+  private int port;
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+    registry.add("spring.datasource.username", POSTGRES::getUsername);
+    registry.add("spring.datasource.password", POSTGRES::getPassword);
+    registry.add(
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri",
+        () -> keycloakBaseUrl() + "/realms/task-manager"
+    );
+    registry.add("app.security.oauth2.client-id", () -> "task-manager-api");
+    registry.add("app.exports.storage-dir", () -> "target/test-exports");
+  }
+
+  @BeforeEach
+  void setupRestAssured() {
+    RestAssured.baseURI = "http://localhost";
+    RestAssured.port = port;
+  }
+
+  @AfterAll
+  static void stopContainers() {
+    KEYCLOAK.stop();
+    POSTGRES.stop();
+  }
+
+  @Test
+  void requestExportAwaitDoneAndDownloadCsv() throws InterruptedException {
+    String token = obtainAccessToken("user1", "user1pass");
+    Number projectId = createProject(token, uniqueName("project"));
+
+    createTask(token, projectId.longValue(), "alpha export task", Instant.parse("2034-01-01T10:00:00Z"));
+    createTask(token, projectId.longValue(), "beta export task", Instant.parse("2034-01-02T10:00:00Z"));
+
+    Number jobId = given()
+        .auth()
+        .oauth2(token)
+        .contentType(ContentType.JSON)
+        .body(Map.of(
+            "projectId", projectId.longValue(),
+            "type", "CSV"
+        ))
+        .when()
+        .post("/api/v1/exports")
+        .then()
+        .statusCode(202)
+        .extract()
+        .path("jobId");
+
+    awaitDone(token, jobId.longValue());
+
+    String csv = given()
+        .auth()
+        .oauth2(token)
+        .when()
+        .get("/api/v1/exports/{jobId}/download", jobId.longValue())
+        .then()
+        .statusCode(200)
+        .header("Content-Type", containsString("text/csv"))
+        .extract()
+        .asString();
+
+    assertTrue(csv.contains("id,title,description,status,dueAt,completedAt,priority"));
+    assertTrue(csv.contains("alpha export task"));
+    assertTrue(csv.contains("beta export task"));
+  }
+
+  @Test
+  void nonOwnerGets404ForStatusAndDownload() throws InterruptedException {
+    String ownerToken = obtainAccessToken("user1", "user1pass");
+    String otherToken = obtainAccessToken("user2", "user2pass");
+
+    Number projectId = createProject(ownerToken, uniqueName("project"));
+    createTask(ownerToken, projectId.longValue(), "private export task", Instant.parse("2034-02-01T10:00:00Z"));
+
+    Number jobId = given()
+        .auth()
+        .oauth2(ownerToken)
+        .contentType(ContentType.JSON)
+        .body(Map.of(
+            "projectId", projectId.longValue(),
+            "type", "CSV"
+        ))
+        .when()
+        .post("/api/v1/exports")
+        .then()
+        .statusCode(202)
+        .extract()
+        .path("jobId");
+
+    awaitDone(ownerToken, jobId.longValue());
+
+    given()
+        .auth()
+        .oauth2(otherToken)
+        .when()
+        .get("/api/v1/exports/{jobId}", jobId.longValue())
+        .then()
+        .statusCode(404);
+
+    given()
+        .auth()
+        .oauth2(otherToken)
+        .when()
+        .get("/api/v1/exports/{jobId}/download", jobId.longValue())
+        .then()
+        .statusCode(404);
+  }
+
+  private void awaitDone(String token, Long jobId) throws InterruptedException {
+    Instant deadline = Instant.now().plusSeconds(10);
+
+    while (Instant.now().isBefore(deadline)) {
+      Map<String, Object> response = given()
+          .auth()
+          .oauth2(token)
+          .when()
+          .get("/api/v1/exports/{jobId}", jobId)
+          .then()
+          .statusCode(200)
+          .extract()
+          .as(Map.class);
+
+      String status = (String) response.get("status");
+      if ("DONE".equals(status)) {
+        return;
+      }
+      if ("FAILED".equals(status)) {
+        fail("Export job failed: " + response.get("errorMessage"));
+      }
+
+      Thread.sleep(200);
+    }
+
+    fail("Export job did not finish within timeout");
+  }
+
+  private Number createProject(String token, String name) {
+    return given()
+        .auth()
+        .oauth2(token)
+        .contentType(ContentType.JSON)
+        .body(Map.of("name", name))
+        .when()
+        .post("/api/v1/projects")
+        .then()
+        .statusCode(201)
+        .extract()
+        .path("id");
+  }
+
+  private Number createTask(String token, Long projectId, String title, Instant dueAt) {
+    return given()
+        .auth()
+        .oauth2(token)
+        .contentType(ContentType.JSON)
+        .body(Map.of(
+            "title", title,
+            "description", "desc-" + title,
+            "dueAt", dueAt.toString(),
+            "priority", "MEDIUM"
+        ))
+        .when()
+        .post("/api/v1/projects/{projectId}/tasks", projectId)
+        .then()
+        .statusCode(201)
+        .extract()
+        .path("id");
+  }
+
+  private static String obtainAccessToken(String username, String password) {
+    return given()
+        .baseUri(keycloakBaseUrl())
+        .contentType(ContentType.URLENC)
+        .formParam("grant_type", "password")
+        .formParam("client_id", "task-manager-api")
+        .formParam("username", username)
+        .formParam("password", password)
+        .when()
+        .post("/realms/task-manager/protocol/openid-connect/token")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("access_token");
+  }
+
+  private static String uniqueName(String prefix) {
+    return prefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+  }
+
+  private static String keycloakBaseUrl() {
+    return "http://" + KEYCLOAK.getHost() + ":" + KEYCLOAK.getMappedPort(8080);
+  }
+}


### PR DESCRIPTION
Implemented changes for[ issue](https://github.com/LenaNeshcheret/task-manager-pro/issues/10)


- Added CSV generation for project tasks, including file storage on disk.
- Added owner-scoped access checks so non-owners receive `404`.
- Added download protection so requesting the file before completion returns `409`.
- Added integration coverage for:
  - creating tasks
  - requesting export and receiving `202`
  - polling until `DONE`
  - downloading CSV and verifying headers/task titles
  - non-owner access returning `404`
- Only `CSV` exports are supported in this implementation.
- Export storage directory is configurable through application properties.
- Added `ExportEndpointIntegrationTest`
- Tests were not executed in this environment because `mvn` was unavailable and the repository does not include `mvnw`